### PR TITLE
Bump dependency versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Add this file.
 - Add the "Maintenance of GitHub Actions" section to the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
 - Update the "Maintenance of GitHub Actions" section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
+* Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - Add this file.
 - Add the "Maintenance of GitHub Actions" section to the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
 - Update the "Maintenance of GitHub Actions" section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
-* Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
+- Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
+sphinx==8.1.3
+sphinx_rtd_theme==3.0.2
 sphinx-epytext==0.0.4
 recommonmark==0.7.1
 enum-tools[sphinx]==0.9.0


### PR DESCRIPTION
This one has three commits instead of two because I messed up the syntax of the `CHANGELOG.md` entry and fixed it in a new commit.
