### PR TITLE
Update requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
 - Update all sections in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file and add a section.
 - Fix broken link in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
+- Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==8.1.3
+sphinx==8.2.1
 sphinx_rtd_theme==3.0.2
 sphinx-epytext==0.0.4
 recommonmark==0.7.1
-enum-tools[sphinx]==0.9.0
+enum-tools[sphinx]==0.12.0


### PR DESCRIPTION
Update **sphinx** and **enum-tools** to latest versions in the `requirements.txt` file to fix the Sphinx build error on merge.
