### PR TITLE
Update intro to fix invalid syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Update all sections in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file and add a section.
 - Fix broken link in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
 - Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
+- Fix invalid syntax in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.

--- a/intro.rst
+++ b/intro.rst
@@ -11,38 +11,38 @@ We are including the glossary of AutoKey terms at the beginning of the
 users manual because understanding our definitions of the terms, as they
 apply to AutoKey, will make understanding the AutoKey much easier.
 
--  **abbreviation** is a short sequence of letters, numbers or symbols
-   that when typed will trigger AutoKey to do something (run a script,
-   insert a phrase, display a menu).
--  **AutoKey icon** - the letter “A” icon that appears in the
-   notification area or system tray when AutoKey is started. Clicking on
-   the icon opens a pop-up menu that gives you access to AutoKey’s
-   features. The icon can be changed–either by an icon theme or in the
-   preferences menu.
--  **folders** are displayed in the left column of the main window. They
-   can contain sub-folders, scripts and phrases. You can add sub-folders
-   or create new folders as needed.
--  **hotkey** - a key or combination of keys that, when pressed, will
-   trigger AutoKey to do something; run a script, insert a phrase or
-   display a menu. A hotkey can be created using any key on the keyboard
-   (within reason), with or without one or more modifier keys. The
-   modifier keys are Shift, Control, Alt and Super (a.k.a. Windows).
--  **phrase** - a text string or block of text. Phrases can include one
-   or more scripts and their output can add content to the text (ex:
-   current time) or modify it in other ways (ex: position, format,
-   footnotes, etc.).
--  **script** - a small program written in Python. It can start other
-   programs, send commands to a running window, re-size your window,
-   reposition your cursor after execution, etc.
--  **tray menu** - pop-up menu that appears when the AutoKey icon is
-   clicked.
--  **triggers** - hotkeys and typed abbreviations.
--  **macro** - A special ``<tag>`` that can be placed inside a phrase,
-   turning the phrase into a dynamic phrase. Upon phrase expansion, the
-   tags are replaced with text. For example, the ``date`` tag is
-   replaced with the current date and time. For details, see 
-   `Create dynamic phrases by using macros as placeholders 
-   <https://github.com/autokey/autokey/wiki/Phrases#create-dynamic-phrases-by-using-macros-as-placeholders>`__.
+- **abbreviation** is a short sequence of letters, numbers or symbols
+  that when typed will trigger AutoKey to do something (run a script,
+  insert a phrase, display a menu).
+- **AutoKey icon** - the letter "A" icon that appears in the
+  notification area or system tray when AutoKey is started. Clicking on
+  the icon opens a pop-up menu that gives you access to AutoKey's
+  features. The icon can be changed - either by an icon theme or in the
+  preferences menu.
+- **folders** are displayed in the left column of the main window. They
+  can contain sub-folders, scripts and phrases. You can add sub-folders
+  or create new folders as needed.
+- **hotkey** - a key or combination of keys that, when pressed, will
+  trigger AutoKey to do something; run a script, insert a phrase or
+  display a menu. A hotkey can be created using any key on the keyboard
+  (within reason), with or without one or more modifier keys. The
+  modifier keys are Shift, Control, Alt and Super (a.k.a. Windows).
+- **phrase** - a text string or block of text. Phrases can include one
+  or more scripts and their output can add content to the text (ex:
+  current time) or modify it in other ways (ex: position, format,
+  footnotes, etc.).
+- **script** - a small program written in Python. It can start other
+  programs, send commands to a running window, re-size your window,
+  reposition your cursor after execution, etc.
+- **tray menu** - pop-up menu that appears when the AutoKey icon is
+  clicked.
+- **triggers** - hotkeys and typed abbreviations.
+- **macro** - A special ``<tag>`` that can be placed inside a phrase,
+  turning the phrase into a dynamic phrase. Upon phrase expansion, the
+  tags are replaced with text. For example, the ``date`` tag is
+  replaced with the current date and time. For details, see 
+  `Create dynamic phrases by using macros as placeholders 
+  <https://github.com/autokey/autokey/wiki/Phrases#create-dynamic-phrases-by-using-macros-as-placeholders>`__.
 
 How are things organized?
 -------------------------
@@ -60,7 +60,7 @@ Because the metadata file names start with a dot, they are hidden files
 by default and some copy commands like cp will miss them by default.
 rsync will get them. (Credits to Joe)
 
-How to “source” settings on a new computer?
+How to "source" settings on a new computer?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, install (latest) AutoKey on the new computer and press the New
@@ -70,7 +70,7 @@ the left.
 
 Secondly, quit the current AutoKey session through its icon in the
 system tray, and start AutoKey again. Since AutoKey does not monitor its
-“directories” on the fly, restarting it necessary.
+"directories" on the fly, restarting it necessary.
 
 Why Would You Use AutoKey And What Does It Do For You?
 ------------------------------------------------------
@@ -82,9 +82,9 @@ Some examples:
 ~~~~~~~~~~~~~~
 
 There are certain things you type over and over; your address, your
-company name or your custom signature. AutoKey’s abbreviations can
+company name or your custom signature. AutoKey's abbreviations can
 automatically expand a few characters into any of your commonly used
-text blocks. For programmers, AutoKey’s text insertion features can let
+text blocks. For programmers, AutoKey's text insertion features can let
 you easily insert code tags, dividers, etc. at the cursor position.
 
 If you use database, CAD/CAM, engineering or scientific software that
@@ -97,8 +97,8 @@ and close them as well as send keyboard and mouse input to them.
 
 AutoKey works across all applications. Any phrase, script or
 abbreviation can be used in multiple applications. This means you do not
-have to configure all the different applications that you use–you can do
-it once in AutoKey and it works for all your applications.
+have to configure all the different applications that you use - you can
+do it once in AutoKey and it works for all your applications.
 
 AutoKey is very useful if you write or edit business documents, novels,
 documentation, articles, web blogs, programs or fill out a lot of forms.
@@ -120,7 +120,7 @@ to write scripts.
 
 The core part of AutoKey works by sending and receiving keyboard events
 via the X server. It supports multiple ways of communicating with X and
-as such should –in theory– work with any Western keyboard layout.
+as such should - in theory - work with any Western keyboard layout.
 (Problems are known to exist with Russian/Mandarin/Japanese languages)
 
 Common actions
@@ -129,14 +129,14 @@ Common actions
 Adding Abbreviations
 --------------------
 
-On the left side of the configuration window you will see a “tree” view
+On the left side of the configuration window you will see a "tree" view
 of the folders/subfolders already in AutoKey.
 
-Let’s first add a New Top-level folder for the abbreviations you are
+Let's first add a New Top-level folder for the abbreviations you are
 going to add:
 
 File > Create > New Top-level Folder. You can choose to create the new
-folder anywhere you wish, or you may click “Use Default” and type a
+folder anywhere you wish, or you may click "Use Default" and type a
 name. This will create a new folder under the default folder.
 
 Now that we have a new folder, we can start adding abbreviations.
@@ -148,15 +148,15 @@ click OK.
 
 Next press the tab key to get to the big dialog window to enter the
 contents of your phrase. Once the phrase is entered press Ctrl + Tab to
-navigate via keyboard or click on the “Set” button for “Abbreviation”.
-This will bring up a “Set Abbreviation” dialog - this is where you set
-the actual abbreviation for the phrase. Leave the “Trigger on” to
-“Default.” Make sure you leave “Remove typed abbreviation” checked,
+navigate via keyboard or click on the "Set" button for "Abbreviation".
+This will bring up a "Set Abbreviation" dialog - this is where you set
+the actual abbreviation for the phrase. Leave the "Trigger on" to
+"Default." Make sure you leave "Remove typed abbreviation" checked,
 unless you want to leave the abbreviation in the document for some
 reason.
 
-In this example, we’ll set the “Match phrase case to typed abbreviation”
-- this option and “Ignore case of typed abbreviation” work in concert to
+In this example, we'll set the "Match phrase case to typed abbreviation"
+- this option and "Ignore case of typed abbreviation" work in concert to
 let your abbreviation expand with case sensitivity:
 
 ============ ===========
@@ -167,9 +167,8 @@ Tp           The patient
 TP           THE PATIENT
 ============ ===========
 
-Click “OK” or type Alt to accept the abbreviation settings. One last
-step - click “Save” or Control + S to save the changes to the phrase.
+Click "OK" or type Alt to accept the abbreviation settings. One last
+step - click "Save" or Control + S to save the changes to the phrase.
 
 Now, if you type the abbreviation you created in any document or window,
 it will be replaced with the phrase contents you created.
-


### PR DESCRIPTION
* Remove invalid indent from the bullet-list in the "Glossary of AutoKey Terms" section.
* Replace all instances of invalid **“** and **”** characters with **"** character.
* Replace all instances of invalid **’** character with **'** character.
* Replace all instances of invalid **–** character with **-** character.
