### PR TITLE
Update api - fix invalid indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Fix broken link in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
 - Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
 - Fix invalid syntax in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
+- Fix invalid indentation in the [api.rst](https://github.com/autokey/autokey.github.io/blob/master/api.rst) file.

--- a/api.rst
+++ b/api.rst
@@ -3,16 +3,17 @@ Autokey API
 
 Note that the `class` paths are not relevant to everyday autokey scripting. Generally speaking you can call all of these modules directly;
 ::
-    keyboard.send_keys("example document")
-    clipboard.set_content("update clipboard")
 
+  keyboard.send_keys("example document")
+  clipboard.set_content("update clipboard")
 
 Is all that you need to call a method in the keyboard/clipboard API, note that you do not have to worry about import statements.
 
 For the Qt/Gtk pages, these are abstracted, Autokey will select the UI framework most appropriate, you only need to reference these in your scripts as;
 ::
-   dialog.info_dialog("Info dialog", "Test info dialog")
-   clipboard.set_content("clipboard content")
+
+  dialog.info_dialog("Info dialog", "Test info dialog")
+  clipboard.set_content("clipboard content")
 
 .. toctree::
    api/keyboard.rst
@@ -27,4 +28,3 @@ For the Qt/Gtk pages, these are abstracted, Autokey will select the UI framework
    api/engine.rst
    api/highlevel.rst
    api/common.rst
-


### PR DESCRIPTION
This should fix the two errors that complained about unexpected indentation in the [api.rst](https://github.com/autokey/autokey.github.io/blob/master/api.rst) file when tests were run on merges in this repository.
