### PR TITLE
Bump the GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
       - name: install git
         run: |
           sudo apt-get install git -y
@@ -32,7 +32,7 @@ jobs:
           mkdir docs
           sphinx-build -a -E -b html ./ docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
       
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
 - Fix invalid syntax in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
 - Fix invalid indentation in the [api.rst](https://github.com/autokey/autokey.github.io/blob/master/api.rst) file.
+- Bump GitHub actions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
+  


### PR DESCRIPTION
Update the actions in the `pages.yml` file:
* actions/checkout@v6
* actions/upload-pages-artifact@v5
* actions/deploy-pages@v5

The action versions can be verified by following the links in **step 1** of the [Update the actions](https://github.com/autokey/autokey.github.io/blob/master/README.md#update-the-actions) section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
