### PR TITLE
Organize CHANGELOG.md with AutoKey versions and time-stamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
 
-## Documentation
-- Add this file.
-- Add the "Maintenance of GitHub Actions" section to the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
-- Update the "Maintenance of GitHub Actions" section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
-- Bump action versions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
-- Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
-- Update all sections in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file and add a section.
-- Fix broken link in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
-- Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
-- Fix invalid syntax in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
-- Fix invalid indentation in the [api.rst](https://github.com/autokey/autokey.github.io/blob/master/api.rst) file.
-- Bump GitHub actions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
-  
+## Version 0.96.0
+- 2023-08-13 - Add this file.
+- 2023-08-13 - Add the "Maintenance of GitHub Actions" section to the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
+- 2024-10-21 - Update the "Maintenance of GitHub Actions" section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.
+- 2025-01-27 - Bump dependency versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
+- 2025-01-27 - Update all sections in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file and add a section.
+- 2025-02-01 - Bump action versions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
+- 2025-02-26 - Fix broken link in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
+- 2025-02-26 - Bump **sphinx** and **enum-tools** versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
+- 2025-02-27 - Fix invalid syntax in the [intro.rst](https://github.com/autokey/autokey.github.io/blob/master/intro.rst) file.
+- 2025-03-01 - Fix invalid indentation in the [api.rst](https://github.com/autokey/autokey.github.io/blob/master/api.rst) file.
+
+## Version 0.97.0~beta0
+- 2026-05-05 - Bump GitHub actions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
+- 2026-05-07 - Update the [CHANGELOG,d](https://github.com/autokey/autokey.github.io/blob/master/CHANGELOG.md) file to include AutoKey versions and date-stamps.


### PR DESCRIPTION
* The section headings makes it easy to compare events in this repository with events in the [AutoKey](https://github.com/autokey/autokey) repository.
* The time-stamps distinguish similar entries (like version bumps) from one another if they occur more than once per AutoKey version.
