### PR TITLE
Bump requirements txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 ## Version 0.97.0~beta0
 - 2026-05-05 - Bump GitHub actions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
 - 2026-05-07 - Update the [CHANGELOG,d](https://github.com/autokey/autokey.github.io/blob/master/CHANGELOG.md) file to include AutoKey versions and date-stamps.
+- 2026-05-08 - Bump versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==8.2.1
-sphinx_rtd_theme==3.0.2
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0
 sphinx-epytext==0.0.4
 recommonmark==0.7.1
-enum-tools[sphinx]==0.12.0
+enum-tools[sphinx]==0.13.0


### PR DESCRIPTION
* sphinx==9.1.0
* sphinx_rtd_theme==3.1.0
* sphinx-epytext==0.0.4
* recommonmark==0.7.1
* enum-tools[sphinx]==0.13.0

The requirements versions can be verified by following the links in the [Update the dependencies](https://github.com/autokey/autokey.github.io/blob/master/README.md#update-the-dependencies) section in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file.