### PR TITLE
Patch sphinx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - 2026-05-05 - Bump GitHub actions in the [pages.yml](https://github.com/autokey/autokey.github.io/blob/master/.github/workflows/pages.yml) file.
 - 2026-05-07 - Update the [CHANGELOG,d](https://github.com/autokey/autokey.github.io/blob/master/CHANGELOG.md) file to include AutoKey versions and date-stamps.
 - 2026-05-08 - Bump versions in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.
+- 2026-05-08 - Revert the version bump to **sphinx** in the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==9.1.0
+sphinx==8.2.1
 sphinx_rtd_theme==3.1.0
 sphinx-epytext==0.0.4
 recommonmark==0.7.1


### PR DESCRIPTION
Update the [requirements.txt](https://github.com/autokey/autokey.github.io/blob/master/requirements.txt) file:
* Revert the change to the **sphinx** version to restore the version to **8.2.1** and solve the **Could not import extension enum_tools.autoenum** error.

