### PR TITLE
Add a CSS style-sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 - 2026-05-12 - Add the `tox.ini` configuration file for use in testing.
 - 2026-05-12 - Add the missing **_static** directory and populate it with the empty `.gitkeep` file as a temporary placeholder.
 - 2026-05-12 - Update Sphinx and other dependencies in the `requirements.txt` file.
+- 2026-05-14 - Add the **custom.css** file to the **_static** directory and populate it with a selector combination for styling PDF archives of the documentation.

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,4 @@
+/* This targets pages other than the cover page specifically for use by SimplePDF */
+body, .page {
+	background-color: #fafbfc!important;
+	}


### PR DESCRIPTION
* Add the **custom.css** style sheet to the `_static` directory.
* Include a two-selector combination for use by **SimplePDF** in styling the background color of a PDF file of the AutoKey documentation.
