### PR TITLE
Update build-local.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - 2026-05-12 - Add the missing **_static** directory and populate it with the empty `.gitkeep` file as a temporary placeholder.
 - 2026-05-12 - Update Sphinx and other dependencies in the `requirements.txt` file.
 - 2026-05-14 - Add the **custom.css** file to the **_static** directory and populate it with a selector combination for styling PDF archives of the documentation.
+- 2026-05-14 - Make corrections to the `build-local.md` file for clarity and accuracy.

--- a/guides/build-local.md
+++ b/guides/build-local.md
@@ -1,55 +1,57 @@
 # Build the documentation locally
-Build the documentation locally, creating a folder of HTML files similar to the online documentation.
-1. Update the system packages:
+This is a stand-alone guide that provides the steps needed to build the documentation locally and create a folder of HTML files similar to the online documentation. It's intended to be used in a clean, new virtual machine with a fresh installation of **Ubuntu** in it.
+1. Boot into a fresh copy of **Ubuntu 22.04** or **Ubuntu 24.04** in a new virtual machine.
+2. Open a terminal window.
+3. Update the system packages:
    ```bash
    sudo apt update
    ```
-2. Install the core packages:
+4. Install the core packages:
    ```bash
    sudo apt install -y git python3-pip python3-venv
    ```
-3. Create the `~/clones` directory:
+5. Create the `~/clones` directory:
    ```bash
-   mkdir -p ~/clones
+   mkdir ~/clones
    ```
-4. Change to the **clones** directory:
+6. Change to the **clones** directory:
    ```bash
-   cd clones
+   cd ~/clones
    ```
-5. Clone the **AutoKey** and **AutoKey documentation** repositories as siblings in the current directory:
+7. Clone the **AutoKey** and **AutoKey documentation** repositories as siblings in the current directory:
    ```bash
    git clone https://github.com/autokey/autokey.git && git clone https://github.com/autokey/autokey.github.io.git
    ```
-6. Create a virtual environment:
+8. Create a virtual environment:
    ```bash
    python3 -m venv --system-site-packages .venv
    ```
-7. Activate the virtual environment (your prompt will change):
+9. Activate the virtual environment (your prompt will change):
    ```bash
    source .venv/bin/activate
    ```
-8. Change to the **AutoKey documentation** directory:
-   ```bash
-   cd autokey.github.io
-   ```
-9. Install the necessary dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-10. Generate a fresh build of the HTML documentation:
+10. Change to the **AutoKey documentation** directory:
     ```bash
-    make clean html
+    cd autokey.github.io
     ```
-11. Interpret the output:
+11. Install the necessary dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+12. Generate a fresh build of the HTML documentation:
+     ```bash
+     make clean html
+     ```
+13. Interpret the output:
     * You might see some warnings like these in the logs:
       * The **UserWarning: Container node skipped:** warning is just **recommonmark** (the **Markdown** parser) being a bit chatty. You can safely ignore it.
       * The **SyntaxWarning: invalid escape sequence '\+':** is a classic **Python 3.12+** warning. Somewhere in the AutoKey code, there’s a string (likely a Regex) using a backslash that isn't a "raw" string. It’s a tiny bug in the source code, but it won't break your documentation. It can be dealt with by using `r"""` on the offending docstring(s).
       * The **toctree:** warnings (for example, the one warning that the `CHANGELOG.md` file isn't in a **toctree**) means that there’s no link to that file in the main sidebar menu.
-12. Get some visual proof that it worked by viewing the generated documentation in your browser:
+14. Get some visual proof that it worked by viewing the generated documentation in your browser:
     ```bash
     xdg-open _build/html/index.html 2>/dev/null
     ```
-13. Clean up afterwards:
+15. Clean up afterwards:
     1. Deactivate the virtual environment:
        ```bash
        deactivate


### PR DESCRIPTION
Make corrections to the `build-local.md` file:
* Add more information to the introductory text.
* Add two new steps to the beginning of the steps.
* Remove the superfluous **-p** option from the **mkdir** command.
* Use an explicit path when changing to the **~/clones** directory to prevent errors if the current working directory is something other than the home directory.
