### PR TITLE
Add guide for local PDF builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - 2026-05-12 - Update Sphinx and other dependencies in the `requirements.txt` file.
 - 2026-05-14 - Add the **custom.css** file to the **_static** directory and populate it with a selector combination for styling PDF archives of the documentation.
 - 2026-05-14 - Make corrections to the `build-local.md` file for clarity and accuracy.
+- 2026-05-16 - Add a guide for building local PDF documentation.

--- a/guides/build-pdf.md
+++ b/guides/build-pdf.md
@@ -1,0 +1,67 @@
+# Build a local PDF archive
+This is a stand-alone guide that provides the steps needed to generate a single-file, fully searchable PDF version of the documentation using the **SimplePDF** extension for **Sphinx**. The guide is intended to be used in a clean, new virtual machine with a fresh installation of **Ubuntu** in it.
+1. Boot into a fresh copy of **Ubuntu 22.04** or **Ubuntu 24.04** in a new virtual machine.
+2. Open a terminal window.
+3. Update the system packages:
+   ```bash
+   sudo apt update
+   ```
+4. Install the core packages:
+   ```bash
+   sudo apt install -y git python3-pip python3-venv python3-xlib
+   ```
+5. Create the **clones** directory:
+   ```bash
+   mkdir ~/clones
+   ```
+6. Change to the **clones** directory:
+   ```bash
+   cd ~/clones
+   ```
+7. Clone the **AutoKey** and **AutoKey documentation** repositories as siblings in the current directory:
+   ```bash
+   git clone https://github.com/autokey/autokey.git && git clone https://github.com/autokey/autokey.github.io.git
+   ```
+8. Create a virtual environment:
+   ```bash
+   python3 -m venv --system-site-packages .venv
+   ```
+9. Activate the virtual environment (your prompt will change):
+   ```bash
+   source .venv/bin/activate
+   ```
+10. Change to the **AutoKey documentation** directory:
+    ```bash
+    cd autokey.github.io
+    ```
+11. Install the necessary dependencies:
+    ```bash
+    pip install pyinotify sphinx-simplepdf -r requirements.txt
+    ```
+12. Generate a fresh PDF file:
+    ```bash
+    make clean simplepdf
+    ```
+13. Move the generated PDF file to the home directory so it isn't deleted on clean-up:
+    ```bash
+    mv _build/simplepdf/AutoKey_v*.pdf ~/
+    ```
+14. Clean up afterwards:
+    1. Deactivate the virtual environment:
+       ```bash
+       deactivate
+       ```
+    2. Leave the **clones** directory:
+       ```bash
+       cd
+       ```
+    3. Remove the **clones** directory:
+       ```bash
+       rm -rf ~/clones/
+       ```
+
+### Notes:
+* The PDF uses a traditional print layout with a **Table of Contents** rather than a sidebar.
+* The PDF is styled with custom CSS from the repository's `_static` directory.
+* Code blocks keep their syntax highlighting and images are embedded directly. 
+* The PDF file does not contain the **Indices and Tables** section at the end.


### PR DESCRIPTION
Add the **build-pdf.md** guide to the **guides** directory.
* This guide provides step-by-step instructions for building the [AutoKey documentation](https://autokey.github.io/index.html) locally as a **PDF** file.
* The generated **PDF** file is a fully-searchable archive of the [AutoKey documentation](https://autokey.github.io/index.html).
* The instructions in the guide can be modified so that a **PDF** file of the documentation of each release of AutoKey can be generated.
