### PR TITLE
Add guide for local zip builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 - 2026-05-14 - Add the **custom.css** file to the **_static** directory and populate it with a selector combination for styling PDF archives of the documentation.
 - 2026-05-14 - Make corrections to the `build-local.md` file for clarity and accuracy.
 - 2026-05-16 - Add a guide for building local PDF documentation.
+- 2026-05-16 - Add a guide for building a zip archive of the HTML documentation.

--- a/guides/build-zip.md
+++ b/guides/build-zip.md
@@ -1,0 +1,81 @@
+# Build a zip archive of the HTML documentation files
+You can generate a zip file from the HTML documentation files as an archive that can be shared and used to access the documentation offline.
+1. Update the system packages:
+   ```bash
+   sudo apt update
+   ```
+2. Install the core packages:
+   ```bash
+   sudo apt install -y git python3-pip python3-venv zip
+   ```
+3. Create the `**clones** directory:
+   ```bash
+   mkdir -p ~/clones
+   ```
+4. Change to the **clones** directory:
+   ```bash
+   cd clones
+   ```
+5. Clone the **AutoKey** and **AutoKey documentation** repositories as siblings in the current directory:
+   ```bash
+   git clone https://github.com/autokey/autokey.git && git clone https://github.com/autokey/autokey.github.io.git
+   ```
+6. Create a virtual environment:
+   ```bash
+   python3 -m venv --system-site-packages .venv
+   ```
+7. Activate the virtual environment (your prompt will change):
+   ```bash
+   source .venv/bin/activate
+   ```
+8. Change to the **AutoKey documentation** directory:
+   ```bash
+   cd autokey.github.io
+   ```
+9. Install the necessary dependencies:
+   *(Note: pyasyncore, pyinotify, and python-xlib are required for modern Ubuntu builds)*
+   ```bash
+   pip install pyasyncore pyinotify python-xlib -r requirements.txt
+   ```
+10. Generate a fresh build of the documentation:
+    ```bash
+    make clean html
+    ```
+11. Verify the build by viewing the generated documentation in your browser:
+    ```bash
+    xdg-open _build/html/index.html 2>/dev/null
+    ```
+12. Create the zip archive from the HTML files:
+    1. Extract the release version from the `conf.py` file:
+       ```bash
+       VERSION=$(python3 -c "import conf; print(conf.release)" | tail -n 1)
+       ```
+    2. Create the zip archive from inside the **html** folder, storing its contents at the root of the zip file and using the extracted version for the name:
+       ```bash
+       (cd _build/html && zip -r "../../autokey-docs_v${VERSION}.zip" .)
+       ```
+    3. Save the zip file to your home directory:
+       ```bash
+       mv autokey-docs_v*.zip ~/
+       ```
+13. Clean up afterwards:
+    1. Deactivate the virtual environment:
+       ```bash
+       deactivate
+       ```
+    2. Leave the **clones** directory:
+       ```bash
+       cd
+       ```
+    3. Remove the **clones** directory:
+       ```bash
+       rm -rf ~/clones/
+       ```
+
+### Notes:
+* Interpret the output:
+  * You may see some warnings, like these, in the log:
+    * The **UserWarning: Container node skipped:** warning is just **recommonmark** (the **Markdown** parser) being a bit chatty. You can safely ignore it.
+    * The **SyntaxWarning: invalid escape sequence '\+':** is a classic **Python 3.12+** warning. Somewhere in the AutoKey code, there’s a string (likely a Regex) using a backslash that isn't a "raw" string. It’s a tiny bug in the source code, but it won't break your documentation. It can be dealt with by using `r"""` on the offending docstring(s).
+    * The **toctree:** warnings (for example, the one warning that the `CHANGELOG.md` file isn't in a **toctree**) means that there’s no link to that file in the main sidebar menu.
+* To use the archive, unzip it and open the `index.html` file. Note that the search bar and some local links may fail offline due to browser security restrictions.


### PR DESCRIPTION
Add the **build-zip.md** guide to the [guides](https://github.com/autokey/autokey.github.io/tree/master/guides) directory.
* This guide provides step-by-step instructions for building the [AutoKey documentation](https://autokey.github.io/index.html) locally as a zipped archive of the HTML files that make up the documentation.
* The generated zipped archive is a fully-searchable archive of the [AutoKey documentation](https://autokey.github.io/index.html).
* Notes are included for user guidance on browser security restrictions (CORS) having the potential to  interfere with local search indices in the unzipped documentation.
* The steps in the guide can be modified to generate a zipped archive of the documentation for any release of AutoKey.
* The archive is portable, the generated documentation is basically a mirror of the [AutoKey documentation](https://autokey.github.io/index.html) online and looks just like it, but since it's a local copy, the search bar and some local links may fail offline due to browser security restrictions.
