### PR TITLE
Add  clone options to build-pdf.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add  clone options to the [build-pdf.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-pdf.md) guide.
 - Migrate [dependencies update procedure](https://github.com/autokey/autokey.github.io/blob/master/README.md#update-the-dependencies) to a stand-alone guide.
 - Migrate [update actions procedure](https://github.com/autokey/autokey.github.io/blob/master/README.md#update-the-actions) to a stand-alone guide.
 - Remove the no-longer-needed `.gitignore` file from the `_static` directory.

--- a/guides/build-pdf.md
+++ b/guides/build-pdf.md
@@ -65,3 +65,16 @@ This is a stand-alone guide that provides the steps needed to generate a single-
 * The PDF is styled with custom CSS from the repository's `_static` directory.
 * Code blocks keep their syntax highlighting and images are embedded directly. 
 * The PDF file does not contain the **Indices and Tables** section at the end.
+* This guide defaults to building the PDF archive of the documentation locally from the **master** branch. Depending on your needs, choose one of these options for the **AutoKey** clone in **step 7** above:
+  * Clone the **develop** branch:
+    ```bash
+    git clone --branch develop --single-branch https://github.com/autokey/autokey.git
+    ```
+  * Clone the **master** branch (current release):
+    ```bash
+    git clone https://github.com/autokey/autokey.git
+    ```
+  * Clone a **pull request**, replacing **123** with the pull request number:
+    ```bash
+    PR=123; git clone https://github.com/autokey/autokey.git && (cd autokey && git fetch origin pull/$PR/head:pull_$PR && git checkout pull_$PR)
+    ```


### PR DESCRIPTION
Add a note about clone options to the [build-pdf.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-pdf.md) guide.
