### PR TITLE
Update cleanup steps in test-local.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add deactivation of the **tox** virtual environment to the cleanup steps in the [test-local.md](https://github.com/autokey/autokey.github.io/blob/master/guides/test-local.md) file.
 - Add a guide for running **tox** tests on a local copy of the documentation.
 - Add a guide for building a tarball archive of the HTML documentation.
 - Make necessary changes to the [build-zip.md](guides/build-zip.md) guide.

--- a/guides/test-local.md
+++ b/guides/test-local.md
@@ -48,11 +48,15 @@ This stand-alone guide provides the steps needed to use **tox** to run local com
     3. Check if the function names and descriptions are visible. If you see names, but no descriptions, or you encounter a **Module not found** error, verify that the **AutoKey** repository was cloned correctly into the `~/clones` directory.
 12. To share the test results, copy the terminal output and paste it into a GitHub Markdown code-block or paste it into a file on your desktop or in your home directory for sharing later.
 13. Clean up the environment:
-    1. Change out of the **clones** directory:
+    1. Deactivate the **tox** virtual environment:
+       ```bash
+       deactivate
+       ```
+    2. Change out of the **clones** directory:
        ```bash
        cd
        ```
-    2. Remove the **clones** directory:
+    3. Remove the **clones** directory:
        ```bash
        rm -rf ~/clones
        ```


### PR DESCRIPTION
* Update the cleanup steps to include deactivating the **tox** virtual environment before changing directories and removing the clones directory.
* Renumber the other two entries in that section accordingly.
