### PR TITLE
Migrate manual site-rebuild procedure to stand-alone guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Migrate the **Run the actions after documentation changes** section of the [README.md](README.md) file to the `rebuild-site.md` stand-alone guide.
 - Add a guide for simulating a **GitHub CI workflow** for confidence in local and remote behavior.
 - Add a guide for running **tox** tests on a local copy of the documentation.
 - Add a guide for building a tarball archive of the HTML documentation.

--- a/guides/rebuild-site.md
+++ b/guides/rebuild-site.md
@@ -1,0 +1,13 @@
+# Rebuild documentation after changes
+When changes are made to the **AutoKey** documentation, the **GitHub Actions workflow** will need to be run manually to rebuild the documentation pages:
+1. Pick one:
+   * Navigate to the workflow:
+     1. Open the [repository](https://github.com/autokey/autokey.github.io).
+     2. Open the **Actions** menu.
+     3. Choose **Build AutoKey pages** in the left pane.
+   * Go directly to the workflow from here:
+     1. Go to [Build Autokey pages](https://github.com/autokey/autokey.github.io/actions/workflows/pages.yml).
+2. Click the **Run workflow** drop-down in the right pane.
+3. Click the **Run workflow** button in the context menu.
+4. Wait for the process to finish.
+5. Open the [documentation](https://autokey.github.io/index.html) and check if the change looks good or if further work is needed.


### PR DESCRIPTION
* Extract the [Run the actions after documentation changes](https://github.com/autokey/autokey.github.io#run-the-actions-after-documentation-changes) maintenance procedure from the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file and put it into its own guide in the [guides](https://github.com/autokey/autokey.github.io/tree/master/guides) directory.
* Remove "new" from step 5 since the documentation isn't new any more.
* This is one of several steps being done in preparation for streamlining the clutter in the [README.md](https://github.com/autokey/autokey.github.io/blob/master/README.md) file in a future PR that will make the various maintenance and update instructions easy to find and link to.
