### PR TITLE
Add guide for maintaining versions in guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add a guide that documents the process for updating the **Ubuntu** versions mentioned in some of the guides.
 - Migrate the **Run the actions after documentation changes** section of the [README.md](README.md) file to the `rebuild-site.md` stand-alone guide.
 - Add a guide for simulating a **GitHub CI workflow** for confidence in local and remote behavior.
 - Add a guide for running **tox** tests on a local copy of the documentation.

--- a/guides/bump-guides.md
+++ b/guides/bump-guides.md
@@ -1,0 +1,7 @@
+# Bump Ubuntu versions mentioned in guides
+As part of regular maintenance of this repository, update the **Ubuntu** versions mentioned in these locations in the [guides](https://github.com/autokey/autokey.github.io/tree/master/guides) to correspond with the **Ubuntu** versions [currently supported by GitHub](https://github.com/actions/runner-images#available-images):
+1. Line 3 of the [build-local.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-local.md) file.
+2. Line 3 of the [build-pdf.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-pdf.md) file.
+3. Line 3 of the [build-tar.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-tar.md) file.
+4. Line 3 of the [build-zip.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-zip.md) file.
+5. Line 28 of the [mock-github.md](https://github.com/autokey/autokey.github.io/blob/master/guides/mock-github.md) file.


### PR DESCRIPTION
Add a repository-maintenance guide that provides the necessary steps for keeping the version-mentions in the [guides](https://github.com/autokey/autokey.github.io/tree/master/guides) directory up-to-date with the **Ubuntu** versions [currently supported by GitHub](https://github.com/actions/runner-images#available-images).
