### PR TITLE
Add guide for bumping version-references in guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add a guide for bumping version-references in repository-maintenance guides that contain them.
 - Update the comments in the `conf.py` file for clarity and succinctness.
 - Migrate the **Run the actions after documentation changes** section of the [README.md](README.md) file to the `rebuild-site.md` stand-alone guide.
 - Add a guide for simulating a **GitHub CI workflow** for confidence in local and remote behavior.

--- a/guides/bump-references-in-guides.md
+++ b/guides/bump-references-in-guides.md
@@ -1,0 +1,10 @@
+# Bump Ubuntu versions mentioned in the documentation guides
+As part of regular maintenance of this repository, update the **Ubuntu** versions mentioned in these **guides** to correspond with the **Ubuntu** versions [currently supported by GitHub](https://github.com/actions/runner-images#available-images):
+1. Do a search for **Ubuntu** in each of these guides and note the currently-specified versions:
+   * [build-local.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-local.md)
+   * [build-pdf.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-pdf.md)
+   * [build-tar.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-tar.md)
+   * [build-zip.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-zip.md)
+   * [mock-github.md](https://github.com/autokey/autokey.github.io/blob/master/guides/mock-github.md)
+2. Check the current **Ubuntu** versions in the [Available Images](https://github.com/actions/runner-images#available-images) section in the [GitHub Actions Runner Images](https://github.com/actions/runner-images) page.
+3. Compare GitHub's versions with the ones in the guides and update any that have changed.


### PR DESCRIPTION
Add a repository-maintenance guide that provides a list of [guides](https://github.com/autokey/autokey.github.io/tree/master/guides) with references to specific **Ubuntu** versions in them so that those references can be periodically updated to the **Ubuntu** versions currently supported by **GitHub**.