### PR TITLE
Reorganize conf.py extensions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Reorganize the **extensions** list in the `conf.py` file.
 - Add a guide for bumping version-references in repository-maintenance guides that contain them.
 - Add and remove white-space in the `conf.py` file for layout improvement.
 - Update the comments in the `conf.py` file for clarity and succinctness.

--- a/conf.py
+++ b/conf.py
@@ -74,12 +74,15 @@ release = version = get_autokey_version()
 # processed in the listed order. Both native (named 'sphinx.ext.*') and
 # custom extensions are accepted:
 extensions = [
+    # Core Sphinx extensions:
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
+    # Format parsers and styling:
     'recommonmark',
     'sphinx_rtd_theme',
+    # Third-party code documenters:
+    'enum_tools.autoenum',
     'sphinx_epytext',
-    'enum_tools.autoenum'
 ]
 
 # Map file extensions to their respective markup languages:


### PR DESCRIPTION
* Reorganize the **extensions** list in the `conf.py` file.
* Add comments to categorize that list by purpose.
* Add missing comma to the end of the `'enum_tools.autoenum'` entry in that list.
* Rearrange the last two items in that list alphabetically.
