### PR TITLE
Handle pycache in archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Fix the version-identifier syntax in the `build-tar.md` and `build-zip.md` files.
 - Reorganize the **extensions** list in the `conf.py` file.
 - Add a guide for bumping version-references in repository-maintenance guides that contain them.
 - Add and remove white-space in the `conf.py` file for layout improvement.

--- a/guides/build-tar.md
+++ b/guides/build-tar.md
@@ -55,7 +55,7 @@ This is a stand-alone guide that uses **Sphinx** (the Python documentation gener
 15. Create the tarball from the documentation:
     1. Fetch the **AutoKey** version identifier:
        ```bash
-       VERSION=$(python3 -c "import conf; print(conf.release)" | tail -n 1)
+       VERSION=$(python3 -Bc "import conf; print(conf.release)" | tail -n 1)
        ```
     2. Navigate to the `_build/html` directory:
        ```bash

--- a/guides/build-zip.md
+++ b/guides/build-zip.md
@@ -55,7 +55,7 @@ This is a stand-alone guide that uses **Sphinx** (the Python documentation gener
 15. Create the **zip** from the documentation:
     1. Fetch the **AutoKey** version identifier:
        ```bash
-       VERSION=$(python3 -c "import conf; print(conf.release)" | tail -n 1)
+       VERSION=$(python3 -Bc "import conf; print(conf.release)" | tail -n 1)
        ```
     2. Navigate to the `_build/html` directory:
        ```bash


### PR DESCRIPTION
Add the **B** option to the version-identifier to prevent the `__pycache__` directory from being automatically added to the `autokey.github.io` directory and becoming part of the build.

The `__pycache__` directory contains bytecode compiled by the Python interpreter automatically to speed up future loads, which is unnecessary for these stand-alone guides and causes unnecessary and unwanted clutter in the generated archives.
