### PR TITLE
Sort some conf py list and dictionary items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Rearrange some list and dictionary entries alphabetically in the `conf.py` file.
 - Fix the version-identifier syntax in the `build-tar.md` and `build-zip.md` files.
 - Reorganize the **extensions** list in the `conf.py` file.
 - Add a guide for bumping version-references in repository-maintenance guides that contain them.

--- a/conf.py
+++ b/conf.py
@@ -100,11 +100,11 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
     '_build',
-    'Thumbs.db',
     '.DS_Store',
+    'old_wiki', #moved temporarily
     'README.md',
     'scripts',
-    'old_wiki', #moved temporarily
+    'Thumbs.db',
     '.venv',
     '**/.venv',
 ]
@@ -153,9 +153,9 @@ html_context = {
 # List of modules used by the sphinx.ext.autodoc extension to tell Sphinx to
 # fake (mock) specific Python modules during the documentation build process.
 autodoc_mock_imports = [
-    "PyQt5",
     "gi",
     "pyatspi",
+    "PyQt5",
     "tkinter",
     "Tkinter"
 ]
@@ -178,7 +178,7 @@ def setup(app):
 simplepdf_file_name = f"AutoKey_v{release}.pdf"
 # Control style of the PDF and its single-file HTML artifact:
 simplepdf_vars = {
-    'primary': '#598bb9',   # use for accents
-    'cover-bg': '#598bb9',  # use for cover page
     'cover': '#ffffff',     # use for cover text
+    'cover-bg': '#598bb9',  # use for cover page
+    'primary': '#598bb9',   # use for accents
 }


### PR DESCRIPTION
This pull request makes some additional trivial changes to the `conf.py` file to pave the way for some bigger changes coming in a future pull request:
* Rearrange the items in the `conf.py` file's **exclude_patterns** list, the **autodoc_mock_imports** list, and the **simplepdf_vars** dictionary** alphabetically.
