### PR TITLE
Adjust layout of two lists in conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Adjust the layout of two lists in the `conf.py` file from horizontal to vertical.
 - Rearrange some list and dictionary entries alphabetically in the `conf.py` file.
 - Fix the version-identifier syntax in the `build-tar.md` and `build-zip.md` files.
 - Reorganize the **extensions** list in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -93,7 +93,9 @@ source_suffix = {
 
 # List of paths, relative to the documentation root directory, that contain
 # templates:
-templates_path = ['_templates']
+templates_path = [
+    '_templates',
+]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -109,7 +111,6 @@ exclude_patterns = [
     '**/.venv',
 ]
 
-
 # -- HTML configuration ------------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages. See the Sphinx documentation
@@ -119,7 +120,9 @@ html_theme = 'sphinx_rtd_theme'
 # List of paths, relative to the documentation root directory, to custom
 # static files (such as style-sheets). These files are copied over after the
 # built-in static files, overwriting them:
-html_static_path = ['_static']
+html_static_path = [
+    '_static',
+]
 
 # Only apply custom CSS style to PDF builds:
 if 'simplepdf' in sys.argv:


### PR DESCRIPTION
This pull request makes some additional trivial changes to the conf.py file to pave the way for some bigger changes coming in a future pull request:
* Use a vertical layout for the *html_static_path** and **templates_path** lists for consistency with all the other lists in the file.
* Remove one unnecessary blank line.
