### PR TITLE
Add regex comment to conf py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add version-extraction comments to the `conf.py` file.
 - Adjust the layout of two lists in the `conf.py` file from horizontal to vertical.
 - Rearrange some list and dictionary entries alphabetically in the `conf.py` file.
 - Fix the version-identifier syntax in the `build-tar.md` and `build-zip.md` files.

--- a/conf.py
+++ b/conf.py
@@ -55,6 +55,8 @@ def get_autokey_version():
             source,
             re.M
         )
+        # match.group(1) captures the outer quotes along with the text.
+        # [1:-1] removes the outer quotes to yield just the version.
         return match.group(1)[1:-1] if match else "unknown"
 
     return search_for("VERSION")


### PR DESCRIPTION
This pull request makes some additional trivial changes to the conf.py file to pave the way for some bigger changes coming in a future pull request:
* Add a comment to the **return** line in the **search_for** function to clarify the version-extraction regex logic that it uses.
