### PR TITLE
Move version comment in conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Move a version comment in the `conf.py` file to a more suitable location inside of its function.
 - Add version-extraction comments to the `conf.py` file.
 - Adjust the layout of two lists in the `conf.py` file from horizontal to vertical.
 - Rearrange some list and dictionary entries alphabetically in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,7 @@ def get_autokey_version():
         )
         # match.group(1) captures the outer quotes along with the text.
         # [1:-1] removes the outer quotes to yield just the version.
+        # The full version, including alpha/beta/rc tags, is returned:
         return match.group(1)[1:-1] if match else "unknown"
 
     return search_for("VERSION")
@@ -67,7 +68,6 @@ project = 'AutoKey'
 # Is there some way to have this be a link to github authors page?
 copyright = '2023, Various'
 author = 'Various'
-# The full version, including alpha/beta/rc tags:
 release = version = get_autokey_version()
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This pull request makes some additional trivial changes to the `conf.py` file to pave the way for some bigger changes coming in a future pull request:
* Move the comment that references the full version into the **get_autokey_version()** function that returns the full version as the more suitable location for it.
