### PR TITLE
Update exclude_patterns in conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Update the **exclude_patterns** list in the `conf.py` file.
 - Update print statements and author/copyright case in the `conf.py` file.
 - Move a version comment in the `conf.py` file to a more suitable location inside of its function.
 - Add version-extraction comments to the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -104,10 +104,12 @@ templates_path = [
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
     'autokey/**',      # Prevents Sphinx from tracking cloned code files as stand-alone pages
-    '**/.DS_Store/**', # Prevents Sphinx from tracking macOS hidden **Desktop Services Store* file
+    '**/.DS_Store',    # Prevents Sphinx from tracking the macOS hidden **Desktop Services Store** file
+    '**/__MACOSX/**',  # Prevents Sphinx from tracking macOS zip metadata directories
+    '**/._*',          # Prevents Sphinx from tracking macOS AppleDouble metadata files
     'guides/**',       # Prevents Sphinx from tracking all guides including future potential sub-directories
-    '*.md',            # Prevents Sphinx from tracking all markdown in the root directory
-    '**/Thumbs.db',    # Prevents Sphinx from tracking all nested Windows thumbnail cache
+    '*.md',            # Prevents Sphinx from tracking all Markdown in the root directory
+    '**/Thumbs.db',    # Prevents Sphinx from tracking all nested Windows thumbnail caches
    '**/.venv/**',      # Prevents Sphinx from tracking all nested virtual environments
 ]
 

--- a/conf.py
+++ b/conf.py
@@ -103,14 +103,12 @@ templates_path = [
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    '_build',
-    '.DS_Store',
-    'old_wiki', #moved temporarily
-    'README.md',
-    'scripts',
-    'Thumbs.db',
-    '.venv',
-    '**/.venv',
+    '_build',     # Sphinx build output directory
+    '.DS_Store',  # macOS hidden **Desktop Services Store* file
+    'guides/**',  # All guides including future potential sub-directories
+    '*.md',       # All markdown in the root directory
+    'Thumbs.db',  # Windows thumbnail cache
+    '**/.venv',   # Nested virtual environments
 ]
 
 # -- HTML configuration ------------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -103,12 +103,12 @@ templates_path = [
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    '_build',     # Sphinx build output directory
-    '.DS_Store',  # macOS hidden **Desktop Services Store* file
-    'guides/**',  # All guides including future potential sub-directories
-    '*.md',       # All markdown in the root directory
-    'Thumbs.db',  # Windows thumbnail cache
-    '**/.venv',   # Nested virtual environments
+    'autokey/**',      # Prevents Sphinx from tracking cloned code files as stand-alone pages
+    '**/.DS_Store/**', # Prevents Sphinx from tracking macOS hidden **Desktop Services Store* file
+    'guides/**',       # Prevents Sphinx from tracking all guides including future potential sub-directories
+    '*.md',            # Prevents Sphinx from tracking all markdown in the root directory
+    '**/Thumbs.db',    # Prevents Sphinx from tracking all nested Windows thumbnail cache
+   '**/.venv/**',      # Prevents Sphinx from tracking all nested virtual environments
 ]
 
 # -- HTML configuration ------------------------------------------------------


### PR DESCRIPTION
Update the **exclude_patterns** list:
* Add comments to all entries for clarity.
* Add the `autokey/**` entry to prevent **Sphinx** from tracking cloned code files as stand-alone pages.
* Add the `*.md` entry to exclude all **Markdown** files in the root directory of the documentation repository.
* Add the `guides/**` entry to exclude all content in the **guides** directory and also exclude future sub-directories.
* Add the `**/__MACOSX/**` entry to prevent **Sphinx** from tracking **macOS zip** metadata directories.
* Add the `**/._*` entry to prevent **Sphinx** from tracking **macOS AppleDouble** metadata files.
* Update the `.DS_Store` entry to include the nested macOS hidden **Desktop Services Store* file.
* Update the `Thumbs.db` entry to include nested Windows thumbnail cache.
* Update the `**/.venv` entry to include the contents of the `.venv` directory.
* Remove the `_build` entry because the `build` directory is created and used by **Sphinx** to store the raw **.rst** or **.md** files for the **View page source** feature, but **Sphinx** never scans it as a source file.
* Remove the `old_wiki` entry since that directory no longer exists.
* Remove the `README.md` entry since that's now excluded by the `*.md` entry.
* Remove the `scripts` entry since that directory no longer exists.
* Remove the `.venv` entry since that directory is already excluded by the existing `**/.venv` entry.
