### PR TITLE
Move autodoc_mock_imports list in conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Move the **autodoc_mock_imports** list to a more appropriate location in the `conf.py` file.
 - Update the **exclude_patterns** list in the `conf.py` file.
 - Update print statements and author/copyright case in the `conf.py` file.
 - Move a version comment in the `conf.py` file to a more suitable location inside of its function.

--- a/conf.py
+++ b/conf.py
@@ -113,6 +113,15 @@ exclude_patterns = [
    '**/.venv/**',      # Prevents Sphinx from tracking all nested virtual environments
 ]
 
+# List of modules used by the sphinx.ext.autodoc extension to tell Sphinx to
+# fake (mock) specific Python modules during the documentation build process.
+autodoc_mock_imports = [
+    "gi",
+    "pyatspi",
+    "PyQt5",
+    "tkinter",
+]
+
 # -- HTML configuration ------------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages. See the Sphinx documentation
@@ -154,16 +163,6 @@ html_context = {
     'github_repo': 'autokey.github.io',
     'github_version': 'master/',
 }
-
-# List of modules used by the sphinx.ext.autodoc extension to tell Sphinx to
-# fake (mock) specific Python modules during the documentation build process.
-autodoc_mock_imports = [
-    "gi",
-    "pyatspi",
-    "PyQt5",
-    "tkinter",
-    "Tkinter"
-]
 
 # Work-around for the module docstring being posted at the top of every API
 # page:


### PR DESCRIPTION
Move the **autodoc_mock_imports** list from the **HTML configuration** section to the **General configuration** section of the `conf.py` file.
