### PR TITLE
Update PDF filename in build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Update the **PDF** fielname in the `conf.py` and `guides/build-pdf.md` files for consistency.
 - Update the **PDF** comments in the `conf.py` file for clarity.
 - Move the **autodoc_mock_imports** list to a more appropriate location in the `conf.py` file.
 - Update the **exclude_patterns** list in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -179,7 +179,7 @@ def setup(app):
 # -- PDF configuration -------------------------------------------------------
 
 # Use AutoKey release version in PDF file names:
-simplepdf_file_name = f"AutoKey_v{release}.pdf"
+simplepdf_file_name = f"autokey-{release}.pdf"
 # Control style of the PDF and its single-file HTML artifact:
 simplepdf_vars = {
     'cover': '#ffffff',     # use for cover text

--- a/conf.py
+++ b/conf.py
@@ -179,7 +179,7 @@ def setup(app):
 # -- PDF configuration -------------------------------------------------------
 
 # Use AutoKey release version in PDF file names:
-simplepdf_file_name = f"autokey-{release}.pdf"
+simplepdf_file_name = f"autokey-docs-{release}.pdf"
 # Control style of the PDF and its single-file HTML artifact:
 simplepdf_vars = {
     'cover': '#ffffff',     # use for cover text

--- a/guides/build-pdf.md
+++ b/guides/build-pdf.md
@@ -44,7 +44,7 @@ This is a stand-alone guide that provides the steps needed to generate a single-
     ```
 13. Move the generated PDF file to the home directory so it isn't deleted on clean-up:
     ```bash
-    mv _build/simplepdf/AutoKey_v*.pdf ~/
+    mv _build/simplepdf/autokey-docs-*.pdf ~/
     ```
 14. Clean up afterwards:
     1. Deactivate the virtual environment:


### PR DESCRIPTION
* Update the PDF filename in the **PDF configuration** section for consistency with the filenames used in the other guides.
* This causes the file generated by following the instructions in the [build-pdf.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-pdf.md) guide to use, for example, the **autokey-docs-0.96.0.pdf** format for its name, making it consistent with the filenames generated by following the steps in the [build-tar.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-tar.md) and [build-zip.md](https://github.com/autokey/autokey.github.io/blob/master/guides/build-zip.md) guides.