### PR TITLE
Remove self-explanatory HTML comment from conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Remove the self-explanatory comment from above the **html_theme** variable in the `conf.py` file.
 - Update the **PDF** fielname in the `conf.py` and `guides/build-pdf.md` files for consistency.
 - Update the **PDF** comments in the `conf.py` file for clarity.
 - Move the **autodoc_mock_imports** list to a more appropriate location in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -124,8 +124,6 @@ autodoc_mock_imports = [
 
 # -- HTML configuration ------------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages. See the Sphinx documentation
-# for a list of built-in themes:
 html_theme = 'sphinx_rtd_theme'
 
 # List of paths, relative to the documentation root directory, to custom


### PR DESCRIPTION
Remove the self-explanatory comment about themes from above the **html_theme** variable in the `conf.py` file.
