### PR TITLE
Move conf.py HTML variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Move several HTML variables to a more suitable location in the `conf.py` file.
 - Remove the self-explanatory comment from above the **html_theme** variable in the `conf.py` file.
 - Update the **PDF** fielname in the `conf.py` and `guides/build-pdf.md` files for consistency.
 - Update the **PDF** comments in the `conf.py` file for clarity.

--- a/conf.py
+++ b/conf.py
@@ -124,7 +124,13 @@ autodoc_mock_imports = [
 
 # -- HTML configuration ------------------------------------------------------
 
+html_favicon = 'favicon.ico'
+html_logo = 'autokey.png'
 html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'logo_only': True,
+    'display_version': True,
+}
 
 # List of paths, relative to the documentation root directory, to custom
 # static files (such as style-sheets). These files are copied over after the
@@ -144,14 +150,6 @@ if 'simplepdf' in sys.argv:
     html_use_index = False
 else:
     html_use_index = True
-
-html_logo = 'autokey.png'
-html_theme_options = {
-    'logo_only': True,
-    'display_version': True,
-}
-
-html_favicon = 'favicon.ico'
 
 # Location of the hosted source files passed to templates. Enables the
 # "Edit on GitHub" behavior in the top right corners of HTML pages:


### PR DESCRIPTION
Move HTML variables up to the top of the **HTML configuration** section to make them easier to find and maintain.
