### PR TITLE
Move conditional PDF blocks to bottom of conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Move two conditional **PDF** blocks to the **PDF configuration** section in the `conf.py` file.
 - Move several HTML variables to a more suitable location in the `conf.py` file.
 - Remove the self-explanatory comment from above the **html_theme** variable in the `conf.py` file.
 - Update the **PDF** fielname in the `conf.py` and `guides/build-pdf.md` files for consistency.

--- a/conf.py
+++ b/conf.py
@@ -139,18 +139,6 @@ html_static_path = [
     '_static',
 ]
 
-# Apply custom CSS style to PDF builds:
-if 'simplepdf' in sys.argv:
-    html_css_files = ['custom.css']
-else:
-    html_css_files = []
-
-# Suppress creation of "Indices and Tables" for PDF builds:
-if 'simplepdf' in sys.argv:
-    html_use_index = False
-else:
-    html_use_index = True
-
 # Location of the hosted source files passed to templates. Enables the
 # "Edit on GitHub" behavior in the top right corners of HTML pages:
 html_context = {
@@ -173,6 +161,17 @@ def setup(app):
     app.connect('autodoc-process-docstring', skip_modules_docstring)
 
 # -- PDF configuration -------------------------------------------------------
+# Apply custom CSS style to PDF builds:
+if 'simplepdf' in sys.argv:
+    html_css_files = ['custom.css']
+else:
+    html_css_files = []
+
+# Suppress creation of "Indices and Tables" for PDF builds:
+if 'simplepdf' in sys.argv:
+    html_use_index = False
+else:
+    html_use_index = True
 
 # Use AutoKey release version in PDF file names:
 simplepdf_file_name = f"autokey-docs-{release}.pdf"


### PR DESCRIPTION
* Move the conditional block that applies custom **CSS** style to **PDF** builds to the **PDF configuration** section at the bottom of the `conf.py` file.
* Move the conditional block that suppresses creation of **"Indices and Tables"** for **PDF** builds to the **PDF configuration** section at the bottom of the `conf.py` file.
