### PR TITLE
Add version information section-heading to conf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Add the **Version information** section-heading to the `conf.py` file
 - Move two conditional **PDF** blocks to the **PDF configuration** section in the `conf.py` file.
 - Move several HTML variables to a more suitable location in the `conf.py` file.
 - Remove the self-explanatory comment from above the **html_theme** variable in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -38,6 +38,8 @@ else:
 # Point Sphinx to the library so it can generate API docs:
 sys.path.insert(0, os.path.join(autokey_root, "lib"))
 
+# -- Version information -----------------------------------------------------
+
 # Use logic from the autokey/setup.py file to get the AutoKey version:
 def get_autokey_version():
     source_file_name = os.path.join(autokey_root, "lib", "autokey", "common.py")


### PR DESCRIPTION
Add the **Version information** section heading to the `conf.py` file to visually separate the sections.
