### PR TITLE
Refactor comment and headings in conf.py for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.97.0~beta0
 <!-- ⬇️ ALWAYS INSERT NEW BULLETED ITEMS DIRECTLY BELOW THIS LINE ⬇️ -->
+- Refactor a comment and headings in the `conf.py` file for clarity.
 - Add the **Version information** section-heading to the `conf.py` file
 - Move two conditional **PDF** blocks to the **PDF configuration** section in the `conf.py` file.
 - Move several HTML variables to a more suitable location in the `conf.py` file.

--- a/conf.py
+++ b/conf.py
@@ -4,17 +4,17 @@
 # list, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
+# -- Imports -----------------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, as shown here.
-#
 import os
 import sys
 import re
 
-# -- Source information ------------------------------------------------------
+# -- Path information---------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, as shown here.
 
 # Determine the absolute path to this conf.py file:
 base_path = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
* Move the comment about paths to the top of the **Source information** section where the paths are defined.
* Rename two section headings:
  * Rename **Path setup** to **Imports** since it only contains imports.
  * Rename the **Source information** section to **Path information** since it only contains path information.
